### PR TITLE
RING-28725 Fix eof encoding on real socket

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -92,8 +92,13 @@ function encodeBufferStep(encodeContext, istreamId) {
         return;
     }
 
-    const dataBytes = encodeContext.istreams[istreamId]
-              .read(encodeContext.data.size);
+    const lastStripe =
+              encodeContext.processedStripe + 1 === encodeContext.nStripe;
+    const toRead = lastStripe ?
+              (encodeContext.size -
+               encodeContext.processedStripe * encodeContext.data.size) :
+              encodeContext.data.size;
+    const dataBytes = encodeContext.istreams[istreamId].read(toRead);
     // Not enough data to fill data buffer (except for end - see below)
     if (dataBytes === null) {
         return;
@@ -144,6 +149,7 @@ function encode(instream, size, dataOutStreams, parityOutStreams, stripeSize) {
 
     // Read handler
     instream.on('readable', () => encodeBufferStep(encodeContext, 0));
+    instream.on('end', () => encodeBufferStep(encodeContext, 0));
 
     // Forward errors to context
     instream.once('error', err => encodeContext.error(err));


### PR DESCRIPTION
Not entirely sure why I had to bypass it
that way. Consider it more of a working
hack. To be rework later on perhaps...

Note: without it split + ecn in hdclient is broken...