### PR TITLE
RING-29369 Properly handle Writabel.write return code

### DIFF
--- a/lib/decode.js
+++ b/lib/decode.js
@@ -62,6 +62,13 @@ function decodeDispatchStep(decodeContext, error) {
     }
 
     let nPending = decodeContext.filteredOstreams.length;
+    const writeCallback = () => {
+        nPending--;
+        if (nPending === 0) {
+            setImmediate(() => decodeContext.unref());
+        }
+    };
+
     decodeContext.filteredOstreams.forEach(
         s => {
             /* Bumped here to handle write callback
@@ -71,19 +78,9 @@ function decodeDispatchStep(decodeContext, error) {
             const writeOk = s.write(
                 toPush,
                 null, /* binary encoding */
-                () => {
-                    nPending--;
-                    if (nPending === 0) {
-                        decodeContext.unref();
-                    }
-                });
+                writeCallback);
             if (!writeOk) {
-                s.once('drain', () => {
-                    nPending--;
-                    if (nPending === 0) {
-                        decodeContext.unref();
-                    }
-                });
+                s.once('drain', writeCallback);
             } else {
                 nPending--;
             }
@@ -253,7 +250,7 @@ function decode(ostream, size, dataStreams, parityStreams, stripeSize) {
         // Input streams MUST be paused, and never pipe'd nor resumed
         s.pause();
         // Forward errors to context
-        s.once('error', err => decodeContext.error(err));
+        s.once('error', err => setImmediate(() => decodeContext.error(err)));
         // Read handler
         s.on('readable', () => decodeBufferStep(
             decodeContext, i, decodeStep));

--- a/lib/decode.js
+++ b/lib/decode.js
@@ -63,15 +63,31 @@ function decodeDispatchStep(decodeContext, error) {
 
     let nPending = decodeContext.filteredOstreams.length;
     decodeContext.filteredOstreams.forEach(
-        s => s.write(
-            toPush,
-            null, /* binary encoding */
-            () => {
+        s => {
+            /* Bumped here to handle write callback
+             * and potentially waiting for 'drain' event
+             */
+            nPending++;
+            const writeOk = s.write(
+                toPush,
+                null, /* binary encoding */
+                () => {
+                    nPending--;
+                    if (nPending === 0) {
+                        decodeContext.unref();
+                    }
+                });
+            if (!writeOk) {
+                s.once('drain', () => {
+                    nPending--;
+                    if (nPending === 0) {
+                        decodeContext.unref();
+                    }
+                });
+            } else {
                 nPending--;
-                if (nPending === 0) {
-                    decodeContext.unref();
-                }
-            }));
+            }
+        });
 }
 
 

--- a/lib/dencode_context.js
+++ b/lib/dencode_context.js
@@ -151,6 +151,10 @@ class DencodeContext {
      *
      * @param {Error} err - Received error
      * @return {undefined}
+     *
+     * @comment This function sends event on output or input stream,
+     * you may want to avoid calling it directly from a stream API
+     * callback (see encode/decode writeCallback).
      */
     error(err) {
         if (!this.inputError) {
@@ -172,6 +176,10 @@ class DencodeContext {
     /**
      * Notify a new stripe has been encoded (back pressure part 2)
      * @return {undefined}
+     *
+     * @comment This function sends event on output or input stream,
+     * you may want to avoid calling it directly from a stream API
+     * callback (see encode/decode writeCallback).
      */
     unref() {
         this.inFlight = false;
@@ -179,7 +187,7 @@ class DencodeContext {
         /* Forward end to all downstreams iff
          * everything was sent */
         if (this.processedStripe === this.nStripe) {
-            this.filteredOstreams.forEach(s => s.emit('end'));
+            this.filteredOstreams.forEach(s => s.end());
         } else { // prepare new chunk
             this._newStripe();
             // Wakeup input streams

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -66,7 +66,9 @@ function encodeDispatchStep(encodeContext, error) {
         const stripeId = i < encodeContext.k ? i : i - encodeContext.k;
         const start = stripeId * stripeSize;
         const end = (stripeId + 1) * stripeSize;
-        s.write(
+
+        nPending++;
+        const writeOk = s.write(
             buffer.slice(start, end),
             null, /* binary encoding */
             () => {
@@ -75,6 +77,16 @@ function encodeDispatchStep(encodeContext, error) {
                     encodeContext.unref();
                 }
             });
+        if (!writeOk) {
+            s.once('drain', () => {
+                nPending--;
+                if (nPending === 0) {
+                    encodeContext.unref();
+                }
+            });
+        } else {
+            nPending--;
+        }
     });
 }
 

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -59,6 +59,13 @@ function encodeDispatchStep(encodeContext, error) {
     // Forward everything to output streams
     let nPending = encodeContext.ostreams.length;
     const stripeSize = encodeContext.stripeSize;
+    const writeCallback = () => {
+        nPending--;
+        if (nPending === 0) {
+            setImmediate(() => encodeContext.unref());
+        }
+    };
+
     encodeContext.ostreams.forEach((s, i) => {
         const buffer = i < encodeContext.k ?
                   encodeContext.getDataBuffer() :
@@ -74,19 +81,9 @@ function encodeDispatchStep(encodeContext, error) {
         const writeOk = s.write(
             buffer.slice(start, end),
             null, /* binary encoding */
-            () => {
-                nPending--;
-                if (nPending === 0) {
-                    encodeContext.unref();
-                }
-            });
+            writeCallback);
         if (!writeOk) {
-            s.once('drain', () => {
-                nPending--;
-                if (nPending === 0) {
-                    encodeContext.unref();
-                }
-            });
+            s.once('drain', writeCallback);
         } else {
             nPending--;
         }
@@ -167,7 +164,7 @@ function encode(instream, size, dataOutStreams, parityOutStreams, stripeSize) {
     instream.on('end', () => encodeBufferStep(encodeContext, 0));
 
     // Forward errors to context
-    instream.once('error', err => encodeContext.error(err));
+    instream.once('error', err => setImmediate(() => encodeContext.error(err)));
 
     return encodeContext;
 }

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -67,6 +67,9 @@ function encodeDispatchStep(encodeContext, error) {
         const start = stripeId * stripeSize;
         const end = (stripeId + 1) * stripeSize;
 
+        /* Bumped here to handle write callback
+         * and potentially waiting for 'drain' event
+         */
         nPending++;
         const writeOk = s.write(
             buffer.slice(start, end),

--- a/lib/repair.js
+++ b/lib/repair.js
@@ -19,8 +19,15 @@ function repairDispatchStep(repairContext, error) {
     }
 
     // Forward everything to output streams
-    let nPending = 0;
+    let nPending = 1; // 1 is the main loop, wait for all to started
     const stripeSize = repairContext.stripeSize;
+    const writeCallback = () => {
+        nPending--;
+        if (nPending === 0) {
+            setImmediate(() => repairContext.unref());
+        }
+    };
+
     repairContext.ostreams.forEach((s, i) => {
         if ((repairContext.targets & (1 << i)) === 0) {
             return;
@@ -31,17 +38,23 @@ function repairDispatchStep(repairContext, error) {
         const stripeId = i < repairContext.k ? i : i - repairContext.k;
         const start = stripeId * stripeSize;
         const end = (stripeId + 1) * stripeSize;
-        nPending++;
-        s.write(
+
+        /* Bumped twice here to handle write callback
+         * and potentially waiting for 'drain' event
+         */
+        nPending += 2;
+        const writeOk = s.write(
             buffer.slice(start, end),
             null, /* binary encoding */
-            () => {
-                nPending--;
-                if (nPending === 0) {
-                    repairContext.unref();
-                }
-            });
+            writeCallback);
+        if (!writeOk) {
+            s.once('drain', writeCallback);
+        } else {
+            nPending--;
+        }
     });
+
+    nPending--; // Release
 }
 
 
@@ -137,7 +150,7 @@ function repair(k, m, istreams, ostreams, size, stripeSize) {
         // Input streams MUST be paused, and never pipe'd nor resumed
         s.pause();
         // Forward errors to context
-        s.once('error', err => repairContext.error(err));
+        s.once('error', err => setImmediate(() => repairContext.error(err)));
         // Read handler
         s.on('readable', () => decodeBufferStep(
             repairContext, i, repairStep));


### PR DESCRIPTION
We currently don't properly implement back pressure
on encoding/decoding output stream. Whenever the writable
stream notifies us to stop wirting (retruning false to 'write
function) we should ease up and wait for the 'drain' event,
as per the stream documentation.